### PR TITLE
Fix port usage in Dockerfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@ data
 
 cloudbuild.yaml
 nginx.conf
+!client/nginx.conf
 __pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV HOST=0.0.0.0
 ENV PYTHONPATH=/app
 ENV PORT=8080
 
+EXPOSE ${PORT}
 
-EXPOSE 8080
+CMD ["sh", "-c", "python -m uvicorn main:app --host 0.0.0.0 --port ${PORT}"]
 
-CMD ["python", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -11,7 +11,7 @@ ENV HOST=0.0.0.0
 ENV PYTHONPATH=/app
 ENV PORT=8080
 
+EXPOSE ${PORT}
 
-EXPOSE 8080
+CMD ["sh", "-c", "python -m uvicorn main:app --host 0.0.0.0 --port ${PORT}"]
 
-CMD ["python", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -8,6 +8,7 @@ RUN npm run build
 
 FROM nginx:alpine
 COPY --from=build /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
-EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
+COPY nginx.conf /etc/nginx/conf.d/default.conf.template
+EXPOSE 8080
+CMD ["sh", "-c", "envsubst '$$PORT' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"]
+

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -1,0 +1,10 @@
+server {
+    listen       ${PORT};
+    server_name  localhost;
+    root   /usr/share/nginx/html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}
+


### PR DESCRIPTION
## Summary
- adjust `.gitignore` so `client/nginx.conf` is tracked
- expose `$PORT` and use it for `uvicorn` in `Dockerfile`s
- add a minimal nginx config that listens on `$PORT`
- update client Dockerfile to substitute `$PORT`

## Testing
- `python -m py_compile backend/*.py backend/utils/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684639488cb4832ea9ffd8cdd2a45fff